### PR TITLE
docker-compose.yamlにプラットフォーム設定を追加

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   mysql:
     build: .
     container_name: mysql-container
+    platform: linux/amd64
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword


### PR DESCRIPTION
# Issue
#1 


# 概要

```
docker compose up -d --build
```
を実行した際に発生した以下のエラーの修正です

```bash
/bin/zsh ~/Documents/raretech/MySQL_hands_on_check % docker compose up -d --build
[+] Running 0/0
[+] Running 0/1l  Building                                                              0.1s 
[+] Building 1.8s (2/2) FINISHED                                        docker:desktop-linux 
 => [mysql internal] load build definition from Dockerfile                              0.0s
 => => transferring dockerfile: 444B                                                    0.0s
 => ERROR [mysql internal] load metadata for docker.io/library/mysql:8.0-debian         1.8s 
------
[+] Running 0/1nal] load metadata for docker.io/library/mysql:8.0-debian:
 ⠏ Service mysql  Building                                                              1.9s 
failed to solve: mysql:8.0-debian: failed to resolve source metadata for docker.io/library/mysql:8.0-debian: no match for platform in manifest: not found
```
